### PR TITLE
【Fixed】`rails g`コマンドの際にassetsファイル、helperが作成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module Achieve
       controller_specs: true,
       request_specs: false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
+
+      g.assets false
+      g.helper false
     end
   end
 end


### PR DESCRIPTION
#1 

`application.rb`の`config.generators do |g|`ブロック内に
```ruby
g.assets false
g.helper false

```
を追記