### PR TITLE
【Fixed】デバッグツールを開発環境へ移動・追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,6 @@ group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 
-  gem 'better_errors'
-
   gem 'capistrano','3.6.0'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
@@ -86,4 +84,5 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
   gem 'pry-rails'
+  gem 'better_errors'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -85,4 +85,5 @@ group :development do
   gem 'web-console', '~> 2.0'
   gem 'pry-rails'
   gem 'better_errors'
+  gem 'binding_of_caller'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ group :development, :test do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 
-  gem 'pry-rails'
   gem 'better_errors'
 
   gem 'capistrano','3.6.0'
@@ -86,4 +85,5 @@ group :development do
   gem 'letter_opener_web'
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+  gem 'pry-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,6 +521,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   better_errors
+  binding_of_caller
   byebug
   cancan
   capistrano (= 3.6.0)


### PR DESCRIPTION
#2 

`Gemfile`内の
```ruby
gem 'pry-rails'
gem 'better_errors'
```
を
`group :development, :test do`ブロックから
`group :development do`ブロックへ移動。

また`group :development do`ブロックへ
```ruby
gem 'binding_of_caller'
```
を追加。
1. `pry-rails`によって`rails c`のシェルがpryになっていることを確認。
2. `better_errors`によってエラー時の画面がデフォルトから変わっていることを確認。
3. `binding_of_caller`により`better_errors`によるエラー画面にシェルが加わっていることを確認。